### PR TITLE
fix: add sso and ssooidc dependencies to fix ClassNotFoundException with AWS SSO credentials

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,14 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>apache-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sso</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ssooidc</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>


### PR DESCRIPTION
## Problem

When using this extension with an AWS SSO profile, Maven throws:

```
java.lang.ClassNotFoundException: software.amazon.awssdk.services.sso.auth.SsoProfileCredentialsProviderFactory
```

## Root Cause

Maven build extensions run in an isolated classloader that only includes the extension's own declared dependencies — not the consuming project's dependencies. The AWS SDK v2 loads `SsoProfileCredentialsProviderFactory` via Java's `ServiceLoader` mechanism, which requires `software.amazon.awssdk:sso` and `software.amazon.awssdk:ssooidc` to be on the **extension's** classpath.

Since these modules are absent from this project's POM, the factory cannot be found even when the consuming project declares them as its own dependencies.

## Fix

Add `sso` and `ssooidc` as compile-scope dependencies. Both versions are managed by the existing AWS SDK BOM (`aws.sdk.version`), so no explicit version pin is needed.

Closes #7