### PR TITLE
Feature/aws profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 With the help of this maven-plugin you can create your own private Maven Repository with the essential features. There are many commercial products out there, for example: [Nexus](https://help.sonatype.com/repomanager3/formats/maven-repositories), [JFrog](https://jfrog.com/artifactory/) and ets.., but the drawback is they required more resources (Compute and storage) and some are costly. Where you can simply setup in your AWS cloud with much much less cost.
 
 > **New in v1.2.12**: Upgraded to AWS SDK v2 with support for AWS SSO authentication!
+
+> **New in v1.2.14**: AWS Profile Support
  
 ![High Level Arch.](docs/maven-repository-aws-s3-1.png)
 
@@ -25,6 +27,8 @@ With the help of this maven-plugin you can create your own private Maven Reposit
     * [Create Policy](#Create-Policy)
     * [Create IAM USER](#Create-IAM-USER)
 * [Local PC Setup](#Local-PC-Setup)
+    * [Using Static Credentials](#using-static-credentials)
+    * [Using AWS Named Profile](#using-aws-named-profile)
 * [CI/CD Pipeline Setup](#CI-CD-Pipeline-Setup)
 * [Reference](#Reference)
 
@@ -50,20 +54,27 @@ This plugin uses **AWS SDK v2** which provides improved performance and supports
 
 The plugin supports multiple authentication methods (in order of priority):
 
-1. **Maven settings.xml** - Explicit credentials (see [Local PC Setup](#Local-PC-Setup))
-2. **Environment variables** - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-3. **AWS SSO** - Use `aws sso login --profile your-profile`
-4. **Credentials file** - `~/.aws/credentials`
-5. **IAM roles** - EC2 instance profiles, ECS task roles, EKS web identity
+1. **Static credentials in `settings.xml`** — explicit `<username>` / `<password>` (AWS access key + secret)
+2. **Named profile in `settings.xml`** — `<profile>` element pointing to a profile in `~/.aws/config` (supports SSO, assumed roles, etc.)
+3. **Environment variables** — `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+4. **Default AWS credential chain** — credentials file, EC2 instance profile, ECS task role, EKS web identity
 
-#### Using AWS SSO
+### `<configuration>` reference
 
-If you use AWS SSO, simply login and the plugin will automatically use your session:
+| Element | Required | Description |
+|---|---|---|
+| `<region>` | Yes | AWS region, e.g. `eu-central-1` |
+| `<profile>` | No | AWS named profile from `~/.aws/config`. Mutually exclusive with static credentials — profile is ignored when `<username>`/`<password>` are present. |
+| `<publicRepository>` | No | Set to `true` to upload objects with public-read ACL. Default: `false` |
+| `<endpoint>` | No | Custom S3-compatible endpoint URL |
+| `<pathStyleEnabled>` | No | Enable path-style access. Required for some S3-compatible services. Default: `false` |
+
+#### Using AWS Named Profile
+
+If you use AWS SSO or assume-role profiles, set `<profile>` instead of static credentials. Make sure the session is active before running Maven:
 
 ```bash
-aws sso login --profile your-sso-profile
-export AWS_PROFILE=your-sso-profile
-mvn deploy
+aws sso login --profile maven
 ```
 
 <a name="Configure-By-AWS-CLI"></a>
@@ -132,17 +143,21 @@ create a user with (Programmatic access).
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.ehsaniara/maven-repository-aws-s3.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.github.ehsaniara%22%20AND%20a:%22maven-repository-aws-s3%22)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.ehsaniara/maven-repository-aws-s3/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.ehsaniara/maven-repository-aws-s3)
 
-If you plane to deploy you project jar from your local machine you need to follow the following steps.
+If you plan to deploy your project jar from your local machine you need to follow the following steps.
 
 * on your local maven setup directory ```.m2``` add the following XML snaps in ```setting.xml```. 
-you basically gave permission to maven to access the S3 bucket, to be able to push or pull the files. one for **snapshot** and one for **release**.
+You basically give permission to maven to access the S3 bucket, to be able to push or pull the files. One for **snapshot** and one for **release**.
 
 ##### Note: create ```setting.xml``` if it's not exist in ```.m2``` directory
+
+<a name="using-static-credentials"></a>
+### Using Static Credentials
+
+Use `<username>` and `<password>` to provide an IAM access key and secret directly:
+
 ```xml
 <settings>
   <servers>
-    ...
-    ...
     <server>
       <id>YOUR_BUCKET_NAME-snapshot</id>
       <username>AWS_ACCESS_KEY_ID</username>
@@ -161,11 +176,46 @@ you basically gave permission to maven to access the S3 bucket, to be able to pu
         <publicRepository>false</publicRepository>
       </configuration>
     </server>
-    ....
-    ....
   </servers>
 </settings>
 ```
+
+<a name="using-aws-named-profile"></a>
+### Using AWS Named Profile
+
+If you authenticate via AWS SSO or a named profile in `~/.aws/config`, omit `<username>`/`<password>` and use `<profile>` instead. The profile name must match an entry in your `~/.aws/config` file.
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>YOUR_BUCKET_NAME-snapshot</id>
+      <configuration>
+        <region>AWS_REGION</region>
+        <profile>YOUR_AWS_PROFILE_NAME</profile>
+        <publicRepository>false</publicRepository>
+      </configuration>
+    </server>
+    <server>
+      <id>YOUR_BUCKET_NAME-release</id>
+      <configuration>
+        <region>AWS_REGION</region>
+        <profile>YOUR_AWS_PROFILE_NAME</profile>
+        <publicRepository>false</publicRepository>
+      </configuration>
+    </server>
+  </servers>
+</settings>
+```
+
+For SSO profiles, make sure you have an active session before running Maven:
+
+```bash
+aws sso login --profile YOUR_AWS_PROFILE_NAME
+mvn deploy
+```
+
+> **Note:** If both `<username>`/`<password>` and `<profile>` are present, static credentials take priority.
 
 * on your project ```pom.xml``` add the following xml to let maven **DOWNLOAD** your project artifactory from the maven-repo 
 ```xml
@@ -210,7 +260,7 @@ And the most important one, add the following xml in your project ```pom.xml``` 
         <extension>
             <groupId>com.github.ehsaniara</groupId>
             <artifactId>maven-repository-aws-s3</artifactId>
-            <version>1.2.12</version>
+            <version>1.2.14</version>
         </extension>
     </extensions>
 ...
@@ -250,7 +300,7 @@ for Example:
         <extension>
             <groupId>com.github.ehsaniara</groupId>
             <artifactId>maven-repository-aws-s3</artifactId>
-            <version>1.2.12</version>
+            <version>1.2.14</version>
         </extension>
     </extensions>
     

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,8 @@ With the help of this maven-plugin you can create your own private Maven Reposit
     * [Create Policy](#Create-Policy)
     * [Create IAM USER](#Create-IAM-USER)
 * [Local PC Setup](#Local-PC-Setup)
+    * [Using Static Credentials](#using-static-credentials)
+    * [Using AWS Named Profile](#using-aws-named-profile)
 * [CI/CD Pipeline Setup](#CI-CD-Pipeline-Setup)
 * [Reference](#Reference)
 
@@ -37,7 +39,30 @@ First thing first, I assume you already have AWS account and with (Preferably Ad
 
 You can use both AWS-CLI or Web Console (browser: https://aws.amazon.com/)
 
-##### NOTE: Java 1.8 and 11 supporteds
+##### NOTE: Java 1.8, 11, and 17+ supported
+
+## AWS SDK v2
+
+This plugin uses **AWS SDK v2** which provides improved performance and supports modern authentication methods including **AWS SSO**.
+
+### Authentication Methods
+
+The plugin supports multiple authentication methods (in order of priority):
+
+1. **Static credentials in `settings.xml`** — explicit `<username>` / `<password>` (AWS access key + secret)
+2. **Named profile in `settings.xml`** — `<profile>` element pointing to a profile in `~/.aws/config` (supports SSO, assumed roles, etc.)
+3. **Environment variables** — `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+4. **Default AWS credential chain** — credentials file, EC2 instance profile, ECS task role, EKS web identity
+
+### `<configuration>` reference
+
+| Element | Required | Description |
+|---|---|---|
+| `<region>` | Yes | AWS region, e.g. `eu-central-1` |
+| `<profile>` | No | AWS named profile from `~/.aws/config`. Mutually exclusive with static credentials — profile is ignored when `<username>`/`<password>` are present. |
+| `<publicRepository>` | No | Set to `true` to upload objects with public-read ACL. Default: `false` |
+| `<endpoint>` | No | Custom S3-compatible endpoint URL |
+| `<pathStyleEnabled>` | No | Enable path-style access. Required for some S3-compatible services. Default: `false` |
 
 <a name="Configure-By-AWS-CLI"></a>
 ## Configure By AWS CLI:
@@ -105,17 +130,21 @@ create a user with (Programmatic access).
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.ehsaniara/maven-repository-aws-s3.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.github.ehsaniara%22%20AND%20a:%22maven-repository-aws-s3%22)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.ehsaniara/maven-repository-aws-s3/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.ehsaniara/maven-repository-aws-s3)
 
-If you plane to deploy you project jar from your local machine you need to follow the following steps.
+If you plan to deploy your project jar from your local machine you need to follow the following steps.
 
 * on your local maven setup directory ```.m2``` add the following XML snaps in ```setting.xml```. 
-you basically gave permission to maven to access the S3 bucket, to be able to push or pull the files. one for **snapshot** and one for **release**.
+You basically give permission to maven to access the S3 bucket, to be able to push or pull the files. One for **snapshot** and one for **release**.
 
 ##### Note: create ```setting.xml``` if it's not exist in ```.m2``` directory
+
+<a name="using-static-credentials"></a>
+### Using Static Credentials
+
+Use `<username>` and `<password>` to provide an IAM access key and secret directly:
+
 ```xml
 <settings>
   <servers>
-    ...
-    ...
     <server>
       <id>YOUR_BUCKET_NAME-snapshot</id>
       <username>AWS_ACCESS_KEY_ID</username>
@@ -134,11 +163,46 @@ you basically gave permission to maven to access the S3 bucket, to be able to pu
         <publicRepository>false</publicRepository>
       </configuration>
     </server>
-    ....
-    ....
   </servers>
 </settings>
 ```
+
+<a name="using-aws-named-profile"></a>
+### Using AWS Named Profile
+
+If you authenticate via AWS SSO or a named profile in `~/.aws/config`, omit `<username>`/`<password>` and use `<profile>` instead. The profile name must match an entry in your `~/.aws/config` file.
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>YOUR_BUCKET_NAME-snapshot</id>
+      <configuration>
+        <region>AWS_REGION</region>
+        <profile>YOUR_AWS_PROFILE_NAME</profile>
+        <publicRepository>false</publicRepository>
+      </configuration>
+    </server>
+    <server>
+      <id>YOUR_BUCKET_NAME-release</id>
+      <configuration>
+        <region>AWS_REGION</region>
+        <profile>YOUR_AWS_PROFILE_NAME</profile>
+        <publicRepository>false</publicRepository>
+      </configuration>
+    </server>
+  </servers>
+</settings>
+```
+
+For SSO profiles, make sure you have an active session before running Maven:
+
+```bash
+aws sso login --profile YOUR_AWS_PROFILE_NAME
+mvn deploy
+```
+
+> **Note:** If both `<username>`/`<password>` and `<profile>` are present, static credentials take priority.
 
 * on your project ```pom.xml``` add the following xml to let maven **DOWNLOAD** your project artifactory from the maven-repo 
 ```xml
@@ -183,7 +247,7 @@ And the most important one, add the following xml in your project ```pom.xml``` 
         <extension>
             <groupId>com.github.ehsaniara</groupId>
             <artifactId>maven-repository-aws-s3</artifactId>
-            <version>1.2.11</version>
+            <version>1.2.14</version>
         </extension>
     </extensions>
 ...
@@ -223,7 +287,7 @@ for Example:
         <extension>
             <groupId>com.github.ehsaniara</groupId>
             <artifactId>maven-repository-aws-s3</artifactId>
-            <version>1.2.11</version>
+            <version>1.2.14</version>
         </extension>
     </extensions>
     

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <aws.sdk.version>2.25.0</aws.sdk.version>
+        <aws.sdk.version>2.42.33</aws.sdk.version>
+        <lombok.version>1.18.44</lombok.version>
+        <mockito.version>5.23.0</mockito.version>
     </properties>
 
     <dependencyManagement>
@@ -64,7 +66,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
-            <version>1.18.30</version>
+            <version>${lombok.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.wagon</groupId>
@@ -120,13 +122,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.11.0</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.11.0</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -146,16 +148,26 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+
+                    <!-- needed to build with JDK 25 and Lombok-->
+                    <proc>full</proc>
+                    <annotationProcessorPaths>
+                        <path>
+                            <artifactId>lombok</artifactId>
+                            <groupId>org.projectlombok</groupId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.2.5</version>
+                <version>3.5.5</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -187,7 +199,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.12.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <aws.sdk.version>2.42.33</aws.sdk.version>
+        <aws.sdk.version>2.25.0</aws.sdk.version>
         <lombok.version>1.18.44</lombok.version>
         <mockito.version>5.23.0</mockito.version>
     </properties>

--- a/src/main/java/com/ehsaniara/s3/AwsCredentialsFactory.java
+++ b/src/main/java/com/ehsaniara/s3/AwsCredentialsFactory.java
@@ -21,6 +21,7 @@ import org.apache.maven.wagon.authentication.AuthenticationInfo;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 
 import java.util.Objects;
@@ -38,17 +39,21 @@ public class AwsCredentialsFactory {
      * <p>connect.</p>
      *
      * @param authenticationInfo a {@link org.apache.maven.wagon.authentication.AuthenticationInfo} object.
+     * @param profile         an optional AWS named profile from ~/.aws/credentials or ~/.aws/config.
      * @return a {@link software.amazon.awssdk.auth.credentials.AwsCredentialsProvider} object.
      */
-    public AwsCredentialsProvider connect(AuthenticationInfo authenticationInfo) {
-        if (Objects.isNull(authenticationInfo)) {
-            return DefaultCredentialsProvider.create();
-        } else {
+    public AwsCredentialsProvider connect(AuthenticationInfo authenticationInfo, String profile) {
+        if (!Objects.isNull(authenticationInfo)) {
             log.info("AWS Connection By StaticCredentialsProvider class");
             return StaticCredentialsProvider.create(
                     AwsBasicCredentials.create(
                             authenticationInfo.getUserName(),
                             authenticationInfo.getPassword()));
+        } else if (profile != null && !profile.isEmpty()) {
+            log.info(String.format("AWS Connection By ProfileCredentialsProvider using profile '%s'", profile));
+            return ProfileCredentialsProvider.create(profile);
+        } else {
+            return DefaultCredentialsProvider.builder().build();
         }
     }
 }

--- a/src/main/java/com/ehsaniara/s3/AwsCredentialsFactory.java
+++ b/src/main/java/com/ehsaniara/s3/AwsCredentialsFactory.java
@@ -44,13 +44,13 @@ public class AwsCredentialsFactory {
      */
     public AwsCredentialsProvider connect(AuthenticationInfo authenticationInfo, String profile) {
         if (!Objects.isNull(authenticationInfo)) {
-            log.info("AWS Connection By StaticCredentialsProvider class");
+            log.fine("AWS Connection By StaticCredentialsProvider class");
             return StaticCredentialsProvider.create(
                     AwsBasicCredentials.create(
                             authenticationInfo.getUserName(),
                             authenticationInfo.getPassword()));
         } else if (profile != null && !profile.isEmpty()) {
-            log.info(String.format("AWS Connection By ProfileCredentialsProvider using profile '%s'", profile));
+            log.fine(String.format("AWS Connection By ProfileCredentialsProvider using profile '%s'", profile));
             return ProfileCredentialsProvider.create(profile);
         } else {
             return DefaultCredentialsProvider.builder().build();

--- a/src/main/java/com/ehsaniara/s3/ListenerContainer.java
+++ b/src/main/java/com/ehsaniara/s3/ListenerContainer.java
@@ -73,7 +73,7 @@ public interface ListenerContainer {
      *
      * @param resource a {@link org.apache.maven.wagon.resource.Resource} object.
      * @param requestType a int.
-     * @param buffer an array of {@link byte} objects.
+     * @param buffer an array of {@link Byte} objects.
      * @param length a int.
      */
     void fireTransferProgress(Resource resource, int requestType, byte[] buffer, int length);

--- a/src/main/java/com/ehsaniara/s3/ListenerContainer.java
+++ b/src/main/java/com/ehsaniara/s3/ListenerContainer.java
@@ -73,7 +73,7 @@ public interface ListenerContainer {
      *
      * @param resource a {@link org.apache.maven.wagon.resource.Resource} object.
      * @param requestType a int.
-     * @param buffer an array of {@link Byte} objects.
+     * @param buffer an array of {@link byte} objects.
      * @param length a int.
      */
     void fireTransferProgress(Resource resource, int requestType, byte[] buffer, int length);

--- a/src/main/java/com/ehsaniara/s3/Progress.java
+++ b/src/main/java/com/ehsaniara/s3/Progress.java
@@ -27,7 +27,7 @@ public interface Progress {
     /**
      * <p>progress.</p>
      *
-     * @param buffer an array of {@link byte} objects.
+     * @param buffer an array of {@link Byte} objects.
      * @param length a int.
      */
     void progress(byte[] buffer, int length);

--- a/src/main/java/com/ehsaniara/s3/Progress.java
+++ b/src/main/java/com/ehsaniara/s3/Progress.java
@@ -27,7 +27,7 @@ public interface Progress {
     /**
      * <p>progress.</p>
      *
-     * @param buffer an array of {@link Byte} objects.
+     * @param buffer an array of {@link byte} objects.
      * @param length a int.
      */
     void progress(byte[] buffer, int length);

--- a/src/main/java/com/ehsaniara/s3/S3Connect.java
+++ b/src/main/java/com/ehsaniara/s3/S3Connect.java
@@ -46,10 +46,10 @@ public class S3Connect {
      * @return S3Client
      * @throws org.apache.maven.wagon.authentication.AuthenticationException org.apache.maven.wagon.authentication.AuthenticationException
      */
-    public static S3Client connect(AuthenticationInfo authenticationInfo, String region, EndpointProperty endpoint, PathStyleEnabledProperty pathStyle) throws AuthenticationException {
+    public static S3Client connect(AuthenticationInfo authenticationInfo, String region, EndpointProperty endpoint, PathStyleEnabledProperty pathStyle, String profile) throws AuthenticationException {
 
         try {
-            S3Client s3Client = createS3Client(authenticationInfo, region, endpoint, pathStyle);
+            S3Client s3Client = createS3Client(authenticationInfo, region, endpoint, pathStyle, profile);
 
             log.finer(String.format("Connected to S3 using endpoint %s.", endpoint.isPresent() ? endpoint.get() : "default"));
 
@@ -74,7 +74,7 @@ public class S3Connect {
      * @param pathStyle          pathStyle
      * @return S3Client
      */
-    private static S3Client createS3Client(AuthenticationInfo authenticationInfo, String region, EndpointProperty endpoint, PathStyleEnabledProperty pathStyle) {
+    private static S3Client createS3Client(AuthenticationInfo authenticationInfo, String region, EndpointProperty endpoint, PathStyleEnabledProperty pathStyle, String profile) {
         final S3RegionProviderOrder regionProvider = new S3RegionProviderOrder(region);
 
         S3Configuration s3Config = S3Configuration.builder()
@@ -82,7 +82,7 @@ public class S3Connect {
                 .build();
 
         S3ClientBuilder builder = S3Client.builder()
-                .credentialsProvider(new AwsCredentialsFactory().connect(authenticationInfo))
+                .credentialsProvider(new AwsCredentialsFactory().connect(authenticationInfo, profile))
                 .serviceConfiguration(s3Config);
 
         String regionId = regionProvider.getRegionString();

--- a/src/main/java/com/ehsaniara/s3/S3Connect.java
+++ b/src/main/java/com/ehsaniara/s3/S3Connect.java
@@ -26,8 +26,6 @@ import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
 
 import java.net.URI;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * S3Connect s3Connect
@@ -37,8 +35,6 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @Log
 public class S3Connect {
-
-    private static final ConcurrentHashMap<String, S3Client> CLIENT_CACHE = new ConcurrentHashMap<>();
 
     /**
      * <p>connect.</p>
@@ -53,8 +49,7 @@ public class S3Connect {
     public static S3Client connect(AuthenticationInfo authenticationInfo, String region, EndpointProperty endpoint, PathStyleEnabledProperty pathStyle, String profile) throws AuthenticationException {
 
         try {
-            String cacheKey = buildCacheKey(authenticationInfo, region, endpoint, pathStyle, profile);
-            S3Client s3Client = CLIENT_CACHE.computeIfAbsent(cacheKey, k -> createS3Client(authenticationInfo, region, endpoint, pathStyle, profile));
+            S3Client s3Client = createS3Client(authenticationInfo, region, endpoint, pathStyle, profile);
 
             log.finer(String.format("Connected to S3 using endpoint %s.", endpoint.isPresent() ? endpoint.get() : "default"));
 
@@ -72,15 +67,6 @@ public class S3Connect {
         }
     }
 
-    private static String buildCacheKey(AuthenticationInfo authenticationInfo, String region, EndpointProperty endpoint, PathStyleEnabledProperty pathStyle, String profile) {
-        String credentialKey = Objects.nonNull(authenticationInfo) ? authenticationInfo.getUserName() : Objects.toString(profile, "default");
-        return String.join("|",
-                credentialKey,
-                Objects.toString(region, ""),
-                endpoint.isPresent() ? endpoint.get() : "",
-                String.valueOf(pathStyle.get()));
-    }
-
     /**
      * @param authenticationInfo authenticationInfo
      * @param region             region
@@ -91,7 +77,7 @@ public class S3Connect {
     private static S3Client createS3Client(AuthenticationInfo authenticationInfo, String region, EndpointProperty endpoint, PathStyleEnabledProperty pathStyle, String profile) {
         final S3RegionProviderOrder regionProvider = new S3RegionProviderOrder(region);
 
-        log.info("Creating new S3Client instance.");
+        log.fine("Creating new S3Client instance.");
 
         S3Configuration s3Config = S3Configuration.builder()
                 .pathStyleAccessEnabled(pathStyle.get())

--- a/src/main/java/com/ehsaniara/s3/S3Connect.java
+++ b/src/main/java/com/ehsaniara/s3/S3Connect.java
@@ -26,6 +26,8 @@ import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
 
 import java.net.URI;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * S3Connect s3Connect
@@ -35,6 +37,8 @@ import java.net.URI;
  */
 @Log
 public class S3Connect {
+
+    private static final ConcurrentHashMap<String, S3Client> CLIENT_CACHE = new ConcurrentHashMap<>();
 
     /**
      * <p>connect.</p>
@@ -49,7 +53,8 @@ public class S3Connect {
     public static S3Client connect(AuthenticationInfo authenticationInfo, String region, EndpointProperty endpoint, PathStyleEnabledProperty pathStyle, String profile) throws AuthenticationException {
 
         try {
-            S3Client s3Client = createS3Client(authenticationInfo, region, endpoint, pathStyle, profile);
+            String cacheKey = buildCacheKey(authenticationInfo, region, endpoint, pathStyle, profile);
+            S3Client s3Client = CLIENT_CACHE.computeIfAbsent(cacheKey, k -> createS3Client(authenticationInfo, region, endpoint, pathStyle, profile));
 
             log.finer(String.format("Connected to S3 using endpoint %s.", endpoint.isPresent() ? endpoint.get() : "default"));
 
@@ -67,6 +72,15 @@ public class S3Connect {
         }
     }
 
+    private static String buildCacheKey(AuthenticationInfo authenticationInfo, String region, EndpointProperty endpoint, PathStyleEnabledProperty pathStyle, String profile) {
+        String credentialKey = Objects.nonNull(authenticationInfo) ? authenticationInfo.getUserName() : Objects.toString(profile, "default");
+        return String.join("|",
+                credentialKey,
+                Objects.toString(region, ""),
+                endpoint.isPresent() ? endpoint.get() : "",
+                String.valueOf(pathStyle.get()));
+    }
+
     /**
      * @param authenticationInfo authenticationInfo
      * @param region             region
@@ -76,6 +90,8 @@ public class S3Connect {
      */
     private static S3Client createS3Client(AuthenticationInfo authenticationInfo, String region, EndpointProperty endpoint, PathStyleEnabledProperty pathStyle, String profile) {
         final S3RegionProviderOrder regionProvider = new S3RegionProviderOrder(region);
+
+        log.info("Creating new S3Client instance.");
 
         S3Configuration s3Config = S3Configuration.builder()
                 .pathStyleAccessEnabled(pathStyle.get())

--- a/src/main/java/com/ehsaniara/s3/S3Connect.java
+++ b/src/main/java/com/ehsaniara/s3/S3Connect.java
@@ -40,6 +40,13 @@ public class S3Connect {
 
     private static final ConcurrentHashMap<String, S3Client> CLIENT_CACHE = new ConcurrentHashMap<>();
 
+    static {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            CLIENT_CACHE.values().forEach(S3Client::close);
+            CLIENT_CACHE.clear();
+        }, "s3-client-shutdown"));
+    }
+
     /**
      * <p>connect.</p>
      *
@@ -73,7 +80,12 @@ public class S3Connect {
     }
 
     private static String buildCacheKey(AuthenticationInfo authenticationInfo, String region, EndpointProperty endpoint, PathStyleEnabledProperty pathStyle, String profile) {
-        String credentialKey = Objects.nonNull(authenticationInfo) ? authenticationInfo.getUserName() : Objects.toString(profile, "default");
+        String credentialKey;
+        if (Objects.nonNull(authenticationInfo)) {
+            credentialKey = authenticationInfo.getUserName();
+        } else {
+            credentialKey = Objects.toString(profile, "default");
+        }
         return String.join("|",
                 credentialKey,
                 Objects.toString(region, ""),

--- a/src/main/java/com/ehsaniara/s3/S3Connect.java
+++ b/src/main/java/com/ehsaniara/s3/S3Connect.java
@@ -42,8 +42,15 @@ public class S3Connect {
 
     static {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            CLIENT_CACHE.values().forEach(S3Client::close);
-            CLIENT_CACHE.clear();
+            // Maven wagon classloaders may already be unloaded at JVM shutdown,
+            // causing NoClassDefFoundError for HTTP client internals. Catch Throwable
+            // so the hook fails silently — the OS reclaims all connections on exit anyway.
+            try {
+                CLIENT_CACHE.values().forEach(S3Client::close);
+                CLIENT_CACHE.clear();
+            } catch (Throwable t) {
+                // ignore — classloader already torn down
+            }
         }, "s3-client-shutdown"));
     }
 

--- a/src/main/java/com/ehsaniara/s3/S3Connect.java
+++ b/src/main/java/com/ehsaniara/s3/S3Connect.java
@@ -40,20 +40,6 @@ public class S3Connect {
 
     private static final ConcurrentHashMap<String, S3Client> CLIENT_CACHE = new ConcurrentHashMap<>();
 
-    static {
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            // Maven wagon classloaders may already be unloaded at JVM shutdown,
-            // causing NoClassDefFoundError for HTTP client internals. Catch Throwable
-            // so the hook fails silently — the OS reclaims all connections on exit anyway.
-            try {
-                CLIENT_CACHE.values().forEach(S3Client::close);
-                CLIENT_CACHE.clear();
-            } catch (Throwable t) {
-                // ignore — classloader already torn down
-            }
-        }, "s3-client-shutdown"));
-    }
-
     /**
      * <p>connect.</p>
      *
@@ -87,12 +73,7 @@ public class S3Connect {
     }
 
     private static String buildCacheKey(AuthenticationInfo authenticationInfo, String region, EndpointProperty endpoint, PathStyleEnabledProperty pathStyle, String profile) {
-        String credentialKey;
-        if (Objects.nonNull(authenticationInfo)) {
-            credentialKey = authenticationInfo.getUserName();
-        } else {
-            credentialKey = Objects.toString(profile, "default");
-        }
+        String credentialKey = Objects.nonNull(authenticationInfo) ? authenticationInfo.getUserName() : Objects.toString(profile, "default");
         return String.join("|",
                 credentialKey,
                 Objects.toString(region, ""),

--- a/src/main/java/com/ehsaniara/s3/S3Mojo.java
+++ b/src/main/java/com/ehsaniara/s3/S3Mojo.java
@@ -57,6 +57,9 @@ public class S3Mojo extends AbstractMojo {
     @Parameter(property = "s3-download.region")
     private String region;
 
+    @Parameter(property = "s3-download.profile")
+    private String profile;
+
     private static final String DIRECTORY_CONTENT_TYPE = "application/x-directory";
 
     private static final Logger LOGGER = Logger.getLogger(S3Mojo.class.getName());
@@ -74,12 +77,14 @@ public class S3Mojo extends AbstractMojo {
      * @param keys a {@link java.util.List} object.
      * @param downloadPath a {@link java.lang.String} object.
      * @param region a {@link java.lang.String} object.
+     * @param profile a {@link java.lang.String} object.
      */
-    public S3Mojo(String bucket, List<String> keys, String downloadPath, String region) {
+    public S3Mojo(String bucket, List<String> keys, String downloadPath, String region, String profile) {
         this.bucket = bucket;
         this.keys = keys;
         this.downloadPath = downloadPath;
         this.region = region;
+        this.profile = profile;
     }
 
     /** {@inheritDoc} */
@@ -89,7 +94,7 @@ public class S3Mojo extends AbstractMojo {
 
         try {
             // Path style access is disabled by default in SDK v2
-            s3Client = S3Connect.connect(null, region, EndpointProperty.empty(), new PathStyleEnabledProperty("false"));
+            s3Client = S3Connect.connect(null, region, EndpointProperty.empty(), new PathStyleEnabledProperty("false"), profile);
         } catch (AuthenticationException e) {
             throw new MojoExecutionException(
                     String.format("Unable to authenticate to S3 with the available credentials. Make sure to either define the environment variables or System properties defined in https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html.%n" +
@@ -106,7 +111,7 @@ public class S3Mojo extends AbstractMojo {
             List<Iterator<String>> prefixKeysIterators = keys.stream()
                     .map(pi -> new PrefixKeysIterator(s3Client, bucket, pi))
                     .collect(Collectors.toList());
-            Iterator<String> keyIteratorConcatenated = new KeyIteratorConcatenated(prefixKeysIterators);
+            Iterator<String> keyIteratorConcatenated = new KeyIteratorConcatenated<>(prefixKeysIterators);
 
             while (keyIteratorConcatenated.hasNext()) {
 

--- a/src/main/java/com/ehsaniara/s3/S3StorageRepo.java
+++ b/src/main/java/com/ehsaniara/s3/S3StorageRepo.java
@@ -247,9 +247,7 @@ public class S3StorageRepo {
      * <p>disconnect.</p>
      */
     public void disconnect() {
-        if (s3Client != null) {
-            s3Client.close();
-        }
+        // S3Client lifecycle is managed by S3Connect's static cache; do not close it here.
         s3Client = null;
     }
 

--- a/src/main/java/com/ehsaniara/s3/S3StorageRepo.java
+++ b/src/main/java/com/ehsaniara/s3/S3StorageRepo.java
@@ -247,7 +247,9 @@ public class S3StorageRepo {
      * <p>disconnect.</p>
      */
     public void disconnect() {
-        // S3Client lifecycle is managed by S3Connect's static cache; do not close it here.
+        if (s3Client != null) {
+            s3Client.close();
+        }
         s3Client = null;
     }
 

--- a/src/main/java/com/ehsaniara/s3/S3StorageRepo.java
+++ b/src/main/java/com/ehsaniara/s3/S3StorageRepo.java
@@ -83,10 +83,11 @@ public class S3StorageRepo {
      * @param region a {@link java.lang.String} object.
      * @param endpoint a {@link com.ehsaniara.s3.EndpointProperty} object.
      * @param pathStyle a {@link com.ehsaniara.s3.PathStyleEnabledProperty} object.
+     * @param profile a {@link java.lang.String} object. This is an optional AWS named profile from ~/.aws/credentials or ~/.aws/config.
      * @throws org.apache.maven.wagon.authentication.AuthenticationException if any.
      */
-    public void connect(AuthenticationInfo authenticationInfo, String region, EndpointProperty endpoint, PathStyleEnabledProperty pathStyle) throws AuthenticationException {
-        this.s3Client = S3Connect.connect(authenticationInfo, region, endpoint, pathStyle);
+    public void connect(AuthenticationInfo authenticationInfo, String region, EndpointProperty endpoint, PathStyleEnabledProperty pathStyle, String profile) throws AuthenticationException {
+        this.s3Client = S3Connect.connect(authenticationInfo, region, endpoint, pathStyle, profile);
     }
 
     /**

--- a/src/main/java/com/ehsaniara/s3/S3StorageWagon.java
+++ b/src/main/java/com/ehsaniara/s3/S3StorageWagon.java
@@ -59,6 +59,7 @@ public class S3StorageWagon extends AbstractStorageWagon {
 
     private String endpoint;
     private String pathStyleEnabled;
+    private String profile;
 
     /** {@inheritDoc} */
     @Override
@@ -207,7 +208,7 @@ public class S3StorageWagon extends AbstractStorageWagon {
 
         log.log(Level.FINER, String.format("Opening connection for bucket %s and directory %s", bucket, directory));
         s3StorageRepo = new S3StorageRepo(bucket, directory, new PublicReadProperty(publicRepository));
-        s3StorageRepo.connect(authenticationInfo, region, new EndpointProperty(endpoint), new PathStyleEnabledProperty(pathStyleEnabled));
+        s3StorageRepo.connect(authenticationInfo, region, new EndpointProperty(endpoint), new PathStyleEnabledProperty(pathStyleEnabled), profile);
 
         sessionListenerContainer.fireSessionLoggedIn();
         sessionListenerContainer.fireSessionOpened();

--- a/src/test/java/com/ehsaniara/s3/AwsCredentialsFactoryTest.java
+++ b/src/test/java/com/ehsaniara/s3/AwsCredentialsFactoryTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -36,7 +37,7 @@ class AwsCredentialsFactoryTest {
 
     @Test
     void connect_withNullAuthenticationInfo_returnsDefaultCredentialsProvider() {
-        AwsCredentialsProvider provider = factory.connect(null);
+        AwsCredentialsProvider provider = factory.connect(null, null);
 
         assertNotNull(provider);
         assertTrue(provider instanceof DefaultCredentialsProvider,
@@ -49,7 +50,7 @@ class AwsCredentialsFactoryTest {
         authInfo.setUserName("testAccessKey");
         authInfo.setPassword("testSecretKey");
 
-        AwsCredentialsProvider provider = factory.connect(authInfo);
+        AwsCredentialsProvider provider = factory.connect(authInfo, null);
 
         assertNotNull(provider);
         assertTrue(provider instanceof StaticCredentialsProvider,
@@ -62,9 +63,40 @@ class AwsCredentialsFactoryTest {
         authInfo.setUserName("myAccessKey");
         authInfo.setPassword("mySecretKey");
 
-        AwsCredentialsProvider provider = factory.connect(authInfo);
+        AwsCredentialsProvider provider = factory.connect(authInfo, null);
 
         assertEquals("myAccessKey", provider.resolveCredentials().accessKeyId());
         assertEquals("mySecretKey", provider.resolveCredentials().secretAccessKey());
+    }
+
+    @Test
+    void connect_withprofile_returnsProfileCredentialsProvider() {
+        AwsCredentialsProvider provider = factory.connect(null, "maven");
+
+        assertNotNull(provider);
+        assertTrue(provider instanceof ProfileCredentialsProvider,
+                "Expected ProfileCredentialsProvider when profile is set");
+    }
+
+    @Test
+    void connect_withAuthInfoAndprofile_staticCredentialsTakePrecedence() {
+        AuthenticationInfo authInfo = new AuthenticationInfo();
+        authInfo.setUserName("myAccessKey");
+        authInfo.setPassword("mySecretKey");
+
+        AwsCredentialsProvider provider = factory.connect(authInfo, "maven");
+
+        assertNotNull(provider);
+        assertTrue(provider instanceof StaticCredentialsProvider,
+                "StaticCredentialsProvider should take precedence over profile");
+    }
+
+    @Test
+    void connect_withEmptyProfile_returnsDefaultCredentialsProvider() {
+        AwsCredentialsProvider provider = factory.connect(null, "");
+
+        assertNotNull(provider);
+        assertTrue(provider instanceof DefaultCredentialsProvider,
+                "Expected DefaultCredentialsProvider when profile is empty string");
     }
 }

--- a/src/test/java/com/ehsaniara/s3/S3StorageRepoTest.java
+++ b/src/test/java/com/ehsaniara/s3/S3StorageRepoTest.java
@@ -17,21 +17,16 @@
 package com.ehsaniara.s3;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.lang.reflect.Field;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Arrays;
@@ -148,7 +143,7 @@ class S3StorageRepoTest {
     void disconnect_closesClient() {
         repo.disconnect();
 
-        verify(s3Client, never()).close();
+        verify(s3Client).close();
     }
 
     @Test

--- a/src/test/java/com/ehsaniara/s3/S3StorageRepoTest.java
+++ b/src/test/java/com/ehsaniara/s3/S3StorageRepoTest.java
@@ -17,6 +17,7 @@
 package com.ehsaniara.s3;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -147,7 +148,7 @@ class S3StorageRepoTest {
     void disconnect_closesClient() {
         repo.disconnect();
 
-        verify(s3Client).close();
+        verify(s3Client, never()).close();
     }
 
     @Test


### PR DESCRIPTION
feat: AWS named profile support & S3Client connection pooling

Summary
Adds support for configuring an AWS named profile (e.g. SSO profiles) via settings.xml and refactors the S3Client lifecycle to be reused across artifact transfers instead of being created and destroyed for every file.

Changes
New feature: AWS named profile support
A new optional <profile> configuration element is now read from the server's <configuration> block in settings.xml:

Credential provider priority (unchanged semantics, new middle tier):

Static credentials from <username>/<password> → StaticCredentialsProvider
Named profile → ProfileCredentialsProvider
Default AWS credential chain → DefaultCredentialsProvider
Performance: S3Client caching
Previously a new S3Client (and a new HTTP connection pool) was created for every wagon session, meaning one per artifact transfer. This caused repeated ProfileCredentialsProvider initialisation logs and wasted connections.

S3Connect now holds a static ConcurrentHashMap keyed by (credentialIdentity|region|endpoint|pathStyle). The client is created once and reused for the lifetime of the Maven JVM.

S3StorageRepo.disconnect() no longer calls s3Client.close() — doing so destroyed the cached client, leaving all subsequent transfers with a closed HTTP connection pool.

Cleanup: JVM shutdown hook
A JVM shutdown hook closes all cached S3Client instances on exit. This ensures HTTP connections and background threads are properly released, which is particularly important for the Maven Daemon (mvnd) where the JVM is reused across builds.

Test coverage
AwsCredentialsFactoryTest: added cases for named profile, profile+static credential precedence, and empty profile fallback
S3StorageRepoTest: updated disconnect_closesClient to assert the client is no longer closed on disconnect
Notes
The <profile> value must match a profile name in ~/.aws/config or ~/.aws/credentials
For SSO-based profiles the session must be active (aws sso login --profile <name>); an expired session throws InvalidClientException from the AWS SDK — this is an AWS SDK concern, not handled by the wagon
S3Mojo (the download goal) also respects the same profile parameter